### PR TITLE
Do not export namespace in params.env in oidc-authservice

### DIFF
--- a/manifests/oidc-authservice/params.env
+++ b/manifests/oidc-authservice/params.env
@@ -6,5 +6,4 @@ application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=/dex
 userid-header=kubeflow-userid
 userid-prefix=
-namespace=istio-system
 gatewaySelector=ingressgateway


### PR DESCRIPTION
Exposing a parameter with the name "namespace" is dangerous - if not set, it is always set to KfDef's namespace (and not the value in defined params.env) by some kfctl magic. Let's rather not expose it.

Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>