### PR TITLE
Implement HTTP redirect on the top of Kubeflow https-gateway overlay

### DIFF
--- a/examples/kfdef.v1.2.0.yaml
+++ b/examples/kfdef.v1.2.0.yaml
@@ -45,6 +45,11 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
+        path: manifests/kubeflow-manifests/istio/istio/base
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
         path: manifests/kubeflow-manifests/stacks/kubernetes/application/cert-manager-crds
     name: cert-manager-crds
   - kustomizeConfig:

--- a/examples/kfdef.v1.2.0.yaml
+++ b/examples/kfdef.v1.2.0.yaml
@@ -114,7 +114,15 @@ spec:
         name: manifests
         path: manifests/kubeflow-manifests/kfserving/installs/generic
     name: kfserving
+  - kustomizeConfig:
+      parameters:
+        - name: gatewaySelector
+          value: ingressgateway
+      repoRef:
+        name: manifests
+        path: manifests/istio/istio/overlays/https-gateway
+    name: istio-https-gateway
   repos:
   - name: manifests
-    uri: github.com/kubermatic/flowmatic?ref=master
+    uri: github.com/jiachengxu/flowmatic?ref=https
   version: v1.2-branch

--- a/examples/kfdef.v1.2.0.yaml
+++ b/examples/kfdef.v1.2.0.yaml
@@ -45,11 +45,6 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: manifests/kubeflow-manifests/istio/istio/base
-    name: istio
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
         path: manifests/kubeflow-manifests/stacks/kubernetes/application/cert-manager-crds
     name: cert-manager-crds
   - kustomizeConfig:
@@ -114,15 +109,7 @@ spec:
         name: manifests
         path: manifests/kubeflow-manifests/kfserving/installs/generic
     name: kfserving
-  - kustomizeConfig:
-      parameters:
-        - name: gatewaySelector
-          value: ingressgateway
-      repoRef:
-        name: manifests
-        path: manifests/istio/istio/overlays/https-gateway
-    name: istio-https-gateway
   repos:
   - name: manifests
-    uri: github.com/jiachengxu/flowmatic?ref=https
+    uri: github.com/kubermatic/flowmatic?ref=master
   version: v1.2-branch

--- a/manifests/istio/istio/base/https-gateway.yaml
+++ b/manifests/istio/istio/base/https-gateway.yaml
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: kubeflow-gateway
-spec:
-  servers:
-  - hosts:
-    - '*'
+- op: add
+  path: /spec/servers/-
+  value:
+    hosts:
+      - '*'
     port:
       name: http
       number: 80
@@ -27,13 +24,3 @@ spec:
     # Upgrade HTTP to HTTPS
     tls:
       httpsRedirect: true
-  - hosts:
-    - '*'
-    port:
-      name: https
-      number: 443
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      privateKey: /etc/istio/ingressgateway-certs/tls.key
-      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt

--- a/manifests/istio/istio/base/https-gateway.yaml
+++ b/manifests/istio/istio/base/https-gateway.yaml
@@ -16,7 +16,7 @@
   path: /spec/servers/-
   value:
     hosts:
-      - '*'
+    - '*'
     port:
       name: http
       number: 80

--- a/manifests/istio/istio/base/kustomization.yaml
+++ b/manifests/istio/istio/base/kustomization.yaml
@@ -16,13 +16,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/kubeflow/manifests/istio/istio/base?ref=v1.2-branch
+  - github.com/kubeflow/manifests/istio/istio/overlays/https-gateway?ref=v1.2-branch
 
-patchesStrategicMerge:
- - https-gateway.yaml
+patches:
+  - path: https-gateway.yaml
+    target:
+      group: networking.istio.io
+      version: v1alpha3
+      kind: Gateway
+      name: kubeflow-gateway
 
 configMapGenerator:
- - name: istio-parameters
-   behavior: merge
-   envs:
-   - params.env
+  - name: istio-parameters
+    behavior: merge
+    envs:
+      - params.env

--- a/manifests/istio/istio/base/kustomization.yaml
+++ b/manifests/istio/istio/base/kustomization.yaml
@@ -16,18 +16,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/kubeflow/manifests/istio/istio/overlays/https-gateway?ref=v1.2-branch
+- github.com/kubeflow/manifests/istio/istio/overlays/https-gateway?ref=v1.2-branch
 
 patches:
-  - path: https-gateway.yaml
-    target:
-      group: networking.istio.io
-      version: v1alpha3
-      kind: Gateway
-      name: kubeflow-gateway
+- path: https-gateway.yaml
+  target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: Gateway
+    name: kubeflow-gateway
 
 configMapGenerator:
-  - name: istio-parameters
-    behavior: merge
-    envs:
-      - params.env
+- name: istio-parameters
+  behavior: merge
+  envs:
+  - params.env


### PR DESCRIPTION
This PR implements HTTP redirect on the top of Kubeflow https-gateway overlay, in this way, we don't need to add the following HTTPS config:
```yaml
  - hosts:	
    - '*'	
    port:	
      name: https	
      number: 443	
      protocol: HTTPS	
    tls:	
      mode: SIMPLE	
      privateKey: /etc/istio/ingressgateway-certs/tls.key	
      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
```
because this is already added in kubeflow https-gateway overlay: https://github.com/kubeflow/manifests/blob/v1.2-branch/istio/istio/overlays/https-gateway/kf-istio-resources.yaml#L9-L18